### PR TITLE
changed image to imply/druid, fixed execution errors

### DIFF
--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -72,7 +72,7 @@ services:
       - KAFKA_ENABLE_KRAFT=false
 
   coordinator:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: coordinator
     profiles: ["druid-jupyter", "all-services"]
     volumes:
@@ -89,7 +89,7 @@ services:
       - environment
 
   broker:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: broker
     profiles: ["druid-jupyter", "all-services"]
     volumes:
@@ -106,7 +106,7 @@ services:
       - environment
 
   historical:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: historical
     profiles: ["druid-jupyter", "all-services"]
     volumes:
@@ -124,7 +124,7 @@ services:
       - environment
 
   middlemanager:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: middlemanager
     profiles: ["druid-jupyter", "all-services"]
     volumes:
@@ -143,7 +143,7 @@ services:
       - environment
 
   router:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: router
     profiles: ["druid-jupyter", "all-services"]
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       - KAFKA_ENABLE_KRAFT=false
 
   coordinator:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: coordinator
     profiles: ["druid-jupyter", "all-services"]
     volumes:
@@ -89,7 +89,7 @@ services:
       - environment
 
   broker:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: broker
     profiles: ["druid-jupyter", "all-services"]
     volumes:
@@ -106,7 +106,7 @@ services:
       - environment
 
   historical:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: historical
     profiles: ["druid-jupyter", "all-services"]
     volumes:
@@ -124,7 +124,7 @@ services:
       - environment
 
   middlemanager:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: middlemanager
     profiles: ["druid-jupyter", "all-services"]
     volumes:
@@ -143,7 +143,7 @@ services:
       - environment
 
   router:
-    image: apache/druid:${DRUID_VERSION:-26.0.0}
+    image: imply/druid:${DRUID_VERSION:-27.0.0}
     container_name: router
     profiles: ["druid-jupyter", "all-services"]
     volumes:

--- a/jupyter-img/druidapi/druidapi/tasks.py
+++ b/jupyter-img/druidapi/druidapi/tasks.py
@@ -21,8 +21,8 @@ REQ_POST_TASK = OVERLORD_BASE + '/task'
 REQ_GET_TASK = REQ_POST_TASK + '/{}'
 REQ_TASK_STATUS = REQ_GET_TASK + '/status'
 REQ_TASK_REPORTS = REQ_GET_TASK + '/reports'
-REQ_END_TASK = REQ_GET_TASK
-REQ_END_DS_TASKS = REQ_END_TASK + '/shutdownAllTasks'
+REQ_END_TASK = REQ_GET_TASK + '/shutdown'
+REQ_END_DS_TASKS =  OVERLORD_BASE + '/datasources/{}/shutdownAllTasks'
 
 class TaskClient:
     '''
@@ -182,7 +182,7 @@ class TaskClient:
         ---------
         `POST /druid/indexer/v1/task/{taskId}/shutdown`
         '''
-        return self.client.post_json(REQ_END_TASK, args=[task_id])
+        return self.client.post_json(REQ_END_TASK, body='', args=[task_id])
 
     def shut_down_tasks_for(self, table):
         '''
@@ -201,4 +201,4 @@ class TaskClient:
         ---------
         `POST /druid/indexer/v1/datasources/{dataSource}/shutdownAllTasks`
         '''
-        return self.client.post_json(REQ_END_DS_TASKS, args=[table])
+        return self.client.post_json(REQ_END_DS_TASKS, body='', args=[table])

--- a/notebooks/01-introduction/02-datagen-intro.ipynb
+++ b/notebooks/01-introduction/02-datagen-intro.ipynb
@@ -595,25 +595,18 @@
    "outputs": [],
    "source": [
     "print(f\"Stop streaming generator: [{datagen.post('/stop/sample_custom','',require_ok=False)}]\")\n",
-    "print(f'Reset offsets for streaming ingestion: [{druid.rest.post(\"/druid/indexer/v1/supervisor/custom_data/reset\",\"\", require_ok=False)}]')\n",
-    "print(f'Stop streaming ingestion: [{druid.rest.post(\"/druid/indexer/v1/supervisor/custom_data/terminate\",\"\", require_ok=False)}]')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0cf53bdc-de7f-425d-84b1-68d0cef420d8",
-   "metadata": {},
-   "source": [
-    "Wait for streaming ingestion to complete and then remove the custom data table:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "87341e7c-f7ab-488c-9913-091f712534cb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "print(f'Pause streaming ingestion: [{druid.rest.post(\"/druid/indexer/v1/supervisor/custom_data/suspend\",\"\", require_ok=False)}]')\n",
+    "\n",
+    "print(f'Shutting down running tasks ...')\n",
+    "tasks = druid.tasks.tasks(state='running', table='custom_data')\n",
+    "while len(tasks)>0:\n",
+    "    for task in tasks:\n",
+    "        print(f\"stopping task [{task['id']}]\")\n",
+    "        druid.tasks.shut_down_task(task['id'])\n",
+    "    tasks = druid.tasks.tasks(state='running', table='custom_data')\n",
+    "\n",
+    "print(f'Reset offsets for re-runnability: [{druid.rest.post(\"/druid/indexer/v1/supervisor/custom_data/reset\",\"\", require_ok=False)}]')\n",
+    "print(f'Terminate streaming ingestion: [{druid.rest.post(\"/druid/indexer/v1/supervisor/custom_data/terminate\",\"\", require_ok=False)}]')\n",
     "print(f\"Drop datasource: [{druid.datasources.drop('custom_data')}]\")"
    ]
   }

--- a/notebooks/02-ingestion/01-streaming-from-kafka.ipynb
+++ b/notebooks/02-ingestion/01-streaming-from-kafka.ipynb
@@ -524,7 +524,7 @@
    "metadata": {},
    "source": [
     "## Cleanup \n",
-    "The following cells stop the data generation and ingestion jobs and removes the datasource from Druid."
+    "The following cell stops data generation, ingestion jobs and removes the datasource from Druid."
    ]
   },
   {
@@ -534,24 +534,19 @@
    "outputs": [],
    "source": [
     "print(f\"Stop streaming generator: [{datagen.post('/stop/social_stream','',require_ok=False)}]\")\n",
-    "print(f'Reset offsets for ingestion: [{druid.rest.post(\"/druid/indexer/v1/supervisor/social_media/reset\",\"\", require_ok=False)}]')\n",
-    "print(f'Stop streaming ingestion: [{druid.rest.post(\"/druid/indexer/v1/supervisor/social_media/terminate\",\"\", require_ok=False)}]')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Once the ingestion process ends and completes any final ingestion steps, remove the datasource with the following cell:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "time.sleep(5) # wait for streaming ingestion tasks to end\n",
+    "print(f'Pause streaming ingestion: [{druid.rest.post(\"/druid/indexer/v1/supervisor/social_media/suspend\",\"\", require_ok=False)}]')\n",
+    "\n",
+    "print(f'Shutting down running tasks ...')\n",
+    "\n",
+    "tasks = druid.tasks.tasks(state='running', table='social_media')\n",
+    "while len(tasks)>0:\n",
+    "    for task in tasks:\n",
+    "        print(f\"...stopping task [{task['id']}]\")\n",
+    "        druid.tasks.shut_down_task(task['id'])\n",
+    "    tasks = druid.tasks.tasks(state='running', table='social_media')\n",
+    "        \n",
+    "print(f'Reset offsets for re-runnability: [{druid.rest.post(\"/druid/indexer/v1/supervisor/social_media/reset\",\"\", require_ok=False)}]')\n",
+    "print(f'Terminate streaming ingestion: [{druid.rest.post(\"/druid/indexer/v1/supervisor/social_media/terminate\",\"\", require_ok=False)}]')\n",
     "print(f\"Drop datasource: [{druid.datasources.drop('social_media')}]\")"
    ]
   },

--- a/notebooks/03-query/02-approx-ranking.ipynb
+++ b/notebooks/03-query/02-approx-ranking.ipynb
@@ -130,7 +130,7 @@
     "PARTITIONED BY DAY\n",
     "'''\n",
     "\n",
-    "sql_client.run_task(sql)\n",
+    "display.run_task(sql)\n",
     "sql_client.wait_until_ready('example-flights-topn')\n",
     "display.table('example-flights-topn')"
    ]
@@ -390,7 +390,7 @@
     "sql = '''\n",
     "SELECT \"Flight_Number_Reporting_Airline\", COUNT(*) AS Flights\n",
     "FROM \"example-flights-topn\"\n",
-    "WHERE \"Flight_Number_Reporting_Airline\" <> ''\n",
+    "WHERE \"Flight_Number_Reporting_Airline\" > 0\n",
     "GROUP BY 1\n",
     "ORDER BY 2 DESC\n",
     "LIMIT 500\n",
@@ -542,7 +542,19 @@
    "id": "f58a1846-5072-4495-b840-a620de3c0442",
    "metadata": {},
    "source": [
-    "The distribution, together with our filters, means that these results are useful for this kind of interactive UI element."
+    "The distribution, together with our filters, means that these results are useful for this kind of interactive UI element.\n",
+    "\n",
+    "### Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4f0f8e6-aca1-4ad1-98a8-b786b4e1ee97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "druid.datasources.drop(\"example-flights-topn\")"
    ]
   },
   {


### PR DESCRIPTION
Since we've created the imply/druid repo on dockerhub and it now contains the 27.0.0 release with multi-arch images, in this PR I've:
- updated docker-compose.yaml <- new image and version 27.0.0 by default
- updated docker-compose-local.yaml <- new image and version 27.0.0 by default
- added task termination logic to prevent left over tasks, 
-- had to fix druidapi/tasks.py to make that work.. missing "body" parameter
- other minor fixes to notebooks to get them to run consistently