### PR TITLE
fixed testing script to validate druid is up

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -12,9 +12,18 @@ To build the custom Jupyter image locally:
 5. Generate the new build using the following command:
 
    ```shell
-   DRUID_VERSION=25.0.0 docker compose --profile all-services -f docker-compose-local.yaml up -d --build
+   DRUID_VERSION=27.0.0 docker compose --profile all-services -f docker-compose-local.yaml up -d --build
    ```
 
    You can change the value of `DRUID_VERSION` or the profile used from the Docker Compose file.
-
-
+6. To test all notebooks,
+   make sure that docker compose is down and all volumes have been deleted, then start tests with: 
+   ```shell
+   cd tests
+   ./test-notebooks.sh
+   ``` 
+7. To test single notebook:
+   ```shell
+   cd tests
+   ./test-notebooks.sh ../notebooks/<path to test notebook>
+   ```

--- a/tests/test-notebooks.sh
+++ b/tests/test-notebooks.sh
@@ -22,10 +22,13 @@ retry() {
 
   exit_code=999
  
-  while [[ $exit_code -ne 0 && $retries -gt 0 ]]; do
+  while [[ "$exit_code" -ne "0" && "$retries" -gt 0 ]]; do
     #run action and consume output, no need to show it
-    output=$action
+    echo " trying...[${action[@]}]"
+    output=`${action[@]}` 
     local exit_code=$?
+    echo "  output: [${output}]"
+    echo "  exit code:${exit_code}"
     retries=$(($retries - 1)) 
     if [[ $exit_code -ne 0 ]]; then
       sleep $sleep_seconds
@@ -47,12 +50,12 @@ fi
 
 # check that druid is running
 echo "Waiting for Druid readiness..."
-retry 'curl http://localhost:8888/status' 50 2
 retry 'curl http://localhost:8081/status' 50 2
 retry 'curl http://localhost:8082/status' 50 2
 retry 'curl http://localhost:8083/status' 50 2
 retry 'curl http://localhost:8091/status' 50 2
-echo "Waiting for Data Generator readiness..."
+retry 'curl http://localhost:8888/status' 50 2
+#echo "Waiting for Data Generator readiness..."
 retry 'curl http://localhost:9999/jobs' 50 2
 
 docker exec -it jupyter pytest --nbmake $TEST_PATH


### PR DESCRIPTION
Fixed testing script so it will correctly verify that Druid is running before starting the test cycle.