### PR TITLE
202310 Replace tutorial launch help link

### DIFF
--- a/notebooks/02-ingestion/01-streaming-from-kafka.ipynb
+++ b/notebooks/02-ingestion/01-streaming-from-kafka.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "This tutorial works with Druid 25.0.0 or later.\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `all-services` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html)."
+    "Launch this tutorial and all prerequisites using the `all-services` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid)."
    ]
   },
   {

--- a/notebooks/02-ingestion/02-working-with-nested-columns.ipynb
+++ b/notebooks/02-ingestion/02-working-with-nested-columns.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "### Run with Docker\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html)."
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid)."
    ]
   },
   {

--- a/notebooks/02-ingestion/03-generating-sketches.ipynb
+++ b/notebooks/02-ingestion/03-generating-sketches.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "#### Run using Docker\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html)."
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid)."
    ]
   },
   {

--- a/notebooks/03-query/00-using-sql-with-druidapi.ipynb
+++ b/notebooks/03-query/00-using-sql-with-druidapi.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "This tutorial works with Druid 25.0.0 or later.\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` or `all-services` profiles of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html).\n",
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` or `all-services` profiles of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid).\n",
     "\n",
     "It will also help to have a working knowledge of SQL.\n",
     "\n",

--- a/notebooks/03-query/01-groupby.ipynb
+++ b/notebooks/03-query/01-groupby.ipynb
@@ -44,7 +44,7 @@
     "`all-services` - includes Jupyter, Druid, and Kafka\n",
     " -->\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html).\n"
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid).\n"
    ]
   },
   {

--- a/notebooks/03-query/03-approxCountDistinct.ipynb
+++ b/notebooks/03-query/03-approxCountDistinct.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "#### Run using Docker\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html).\n",
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid).\n",
     "   "
    ]
   },

--- a/notebooks/03-query/04-approxdataDistribution.ipynb
+++ b/notebooks/03-query/04-approxdataDistribution.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "#### Run using Docker\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html).\n",
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid).\n",
     "   "
    ]
   },

--- a/notebooks/03-query/05-UnionOperations.ipynb
+++ b/notebooks/03-query/05-UnionOperations.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "#### Run using Docker\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html)."
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid)."
    ]
   },
   {

--- a/notebooks/03-query/06-lookup-tables.ipynb
+++ b/notebooks/03-query/06-lookup-tables.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "#### Run with Docker\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html).\n",
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid).\n",
     "   \n",
     "#### Run without Docker\n",
     "\n",

--- a/notebooks/03-query/07-functions-datetime.ipynb
+++ b/notebooks/03-query/07-functions-datetime.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "This tutorial works with Druid 27.0.0 or later.\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html)."
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid)."
    ]
   },
   {

--- a/notebooks/03-query/08-functions-strings.ipynb
+++ b/notebooks/03-query/08-functions-strings.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "This tutorial works with Druid 27.0.0 or later.\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html)."
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid)."
    ]
   },
   {

--- a/notebooks/03-query/09-functions-case.ipynb
+++ b/notebooks/03-query/09-functions-case.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "#### Run with Docker\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html).\n",
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid).\n",
     "   "
    ]
   },

--- a/notebooks/04-api/00-getting-started.ipynb
+++ b/notebooks/04-api/00-getting-started.ipynb
@@ -65,7 +65,7 @@
     "This tutorial works with Druid 25.0.0 or later.\n",
     "\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `druid-jupyter` or `all-services` profiles of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html).\n",
+    "Launch this tutorial and all prerequisites using the `druid-jupyter` or `all-services` profiles of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid).\n",
     "\n",
     " "
    ]

--- a/notebooks/99-contributing/notebook-template.ipynb
+++ b/notebooks/99-contributing/notebook-template.ipynb
@@ -51,7 +51,7 @@
     "`all-services` - includes Jupyter, Druid, and Kafka\n",
     " -->\n",
     "\n",
-    "Launch this tutorial and all prerequisites using the `<PLACE PROFILE NAME HERE>` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see [Docker for Jupyter Notebook tutorials](https://druid.apache.org/docs/latest/tutorials/tutorial-jupyter-docker.html).\n",
+    "Launch this tutorial and all prerequisites using the `<PLACE PROFILE NAME HERE>` profile of the Docker Compose file for Jupyter-based Druid tutorials. For more information, see the Learn Druid repository [readme](https://github.com/implydata/learn-druid).\n",
     "   "
    ]
   },


### PR DESCRIPTION
Replaces the link in the header of all notebooks from the Docker for Jupyter Notebook Tutorials page to the README of the learn-druid repo.