### PR TITLE
Releases index

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@
 
 # Learn Druid
 
-The "Learn Druid" repository contains all manner of resources to help you learn and apply Apache Druid.
+The "Learn Druid" repository contains all manner of resources to help you learn and apply [Apache Druid](https://druid.apache.org/)®.
 
 It contains:
 
 * Jupyter Notebooks that guide you through query, ingestion, and data management with Apache Druid.
 * A Docker Compose file to get you up and running with a learning lab.
+
+Suggestions or comments? Call into the [discussions](https://github.com/implydata/learn-druid/discussions). Found a problem or want to request a notebook? Raise an [issue](https://github.com/implydata/learn-druid/issues). Want to contribute? Raise a [PR](https://github.com/implydata/learn-druid/pulls).
+ 
+Come meet your friendly Apache Druid [community](https://druid.apache.org/community) if you have any questions about the functionality you see here.
 
 ## Pre-requisites
 
@@ -41,7 +45,7 @@ To use the "Learn Druid" Docker Compose, you need:
 
 To get started quickly:
 
-1. Clone this repository locally, if you have not already done so:
+1. Clone the repository:
     
    ```bash
    git clone https://github.com/implydata/learn-druid
@@ -53,14 +57,7 @@ To get started quickly:
     cd learn-druid
    ```
 
-> To refresh your local copy with the latest notebooks:
->
->   ```bash
->   git restore .
->   git pull
->   ```
-
-3. Launch the "Learn Druid" Docker environment:
+3. Launch the environment:
 
    ```bash
    docker compose --profile druid-jupyter up -d
@@ -68,23 +65,56 @@ To get started quickly:
 
    > The first time you launch the environment, it can take a while to start all the services.
 
-4. Navigate to Jupyter Lab in your browser:
+4. Navigate to Jupyter Lab in your browser at `http://localhost:8889/lab`. <br/> From there you can read the introduction or use Jupyter Lab to navigate the notebooks folder.
 
-     http://localhost:8889/lab
+5. When you're finished, stop all services:
 
-From there you can read the introduction or use Jupyter Lab to navigate the notebooks folder.
+```bash
+docker compose --profile druid-jupyter down
+```
 
-<!-- TODO: when notebook gets an update, add a screen shot -->
+Once you have cloned the repository, get the latest version as follows:
+
+```bash
+git restore .
+git pull
+```
+
+While using the notebooks, monitor ingestion tasks, compare query results, and more in the [web console](https://druid.apache.org/docs/latest/operations/web-console) directly at `http://localhost:8888`.
+
+## Profiles
+
+Individual notebooks may state a specific compose profile that you need to use.
+
+Specify the profile after the `--profile` parameter to the `docker compose` command. For example, to start with the `all-services` profile, use this command:
+
+```bash
+docker compose --profile all-services up -d
+```
+
+To stop all services:
+
+```bash
+docker compose --profile all-services down
+```
+
+Run the notebooks against an existing Apache Druid database using the `DRUID_HOST` parameter and the `jupyter` profile.
+
+```bash
+DRUID_HOST=[host address] docker compose --profile jupyter up -d
+```
+
+When you have Druid running on the local machine, use `host.docker.internal` as the _host address_.
+
+```bash
+DRUID_HOST=host.docker.internal docker compose --profile jupyter up -d
+```
 
 ## Components
 
-The Learn Druid environment Docker Compose file includes the following services:
+The Learn Druid environment includes the following services:
 
 [**Jupyter Lab**](https://jupyter.org/): An interactive environment to run Jupyter Notebooks. The image for Jupyter used in the environment contains Python along with all the supporting libraries you need to run the notebooks.
-
-* Jupyter Labs is exposed at:
-
-  http://localhost:8889/
 
 [**Apache Kafka**](https://kafka.apache.org/): Streaming service as a data source for Druid.
 
@@ -92,70 +122,6 @@ The Learn Druid environment Docker Compose file includes the following services:
 
 [**Apache Druid**](https://druid.apache.org/): The currently released version of Apache Druid by default.
 
-You can use the web console to monitor ingestion tasks, compare query results, and more. To learn about the Druid web console, see [Web console](https://druid.apache.org/docs/latest/operations/web-console).
+-
 
-*  The Druid web console is exposed at:
-
-   http://localhost:8888
-
-## Profiles 
-
-You can use the following Docker Compose profiles to start various combinations of the components based upon your specific needs.
-
-Individual notebooks may prescribe a specific profile that you need to use.
-
-### Jupyter only
-
-Use this profile when you want to run the notebooks against an existing Apache Druid database. Use the `DRUID_HOST` parameter to set the Apache Druid host address.
-
-To start Jupyter only:
-
-   ```bash
-  DRUID_HOST=[host address] docker compose --profile jupyter up -d
-   ```
-
-For example, if Druid is running on the local machine:
-
-   ```bash
-  DRUID_HOST=host.docker.internal docker compose --profile jupyter up -d
-   ```
-
-To stop Jupyter:
-
-   ```bash
-  docker compose --profile jupyter down
-   ```
-
-### Jupyter and Druid
-
-Use this profile when you need to query data and do batch ingestion only.
-
-To start Jupyter and Druid:
-
-   ```bash
-   docker compose --profile druid-jupyter up -d
-   ```
-
-To stop Jupyter and Druid:
-
-   ```bash
-   docker compose --profile druid-jupyter down
-   ```
-
-### All services
-
-To start all services:
-
-   ```bash
-   docker compose --profile all-services up -d
-   ```
-
-To stop all services:
-
-   ```bash
-   docker compose --profile all-services down
-   ```
-
-## Feedback and help
-
-For feedback and help, start a discussion in the [Discussions board](https://github.com/implydata/learn-druid/discussions) or make contact in the [docs and training channel](https://apachedruidworkspace.slack.com/archives/docs-and-training) in [Apache Druid Slack](https://druid.apache.org/community/).
+**This repository is not affiliated with, endorsed by, or otherwise associated with the Apache Software Foundation (ASF) or any of its projects.  Apache, Apache Druid, Druid, and the Druid logo are either registered trademarks or trademarks of ASF in the USA and other countries.**

--- a/notebooks/00-releases/README.MD
+++ b/notebooks/00-releases/README.MD
@@ -1,0 +1,6 @@
+# Apache Druid releases
+
+This section contains indexes of new and updated notebooks relating to new releases of Apache Druid.
+
+* [Apache Druid 28](druid-28.md)
+* [Apache Druid 29](druid-29.md)

--- a/notebooks/00-releases/druid-28.md
+++ b/notebooks/00-releases/druid-28.md
@@ -1,0 +1,15 @@
+# Apache Druid 28
+
+Released in November 2023, Druid 28 includes a number standards compatibiility improvements in the [SQL dialect](https://druid.apache.org/docs/latest/querying/sql), to [Apache Kafka ingestion](https://druid.apache.org/docs/latest/development/extensions-core/kafka-ingestion), and opens the door to using data direct from [Deep Storage](https://druid.apache.org/docs/latest/design/deep-storage) through the MSQ engine.
+
+Check out these notebooks, which were introduced or improved following the Druid 28 release.
+
+* [SQL-compatible NULL](../02-ingestion/09-generating-and-working-with-nulls.ipynb)
+* [Multi-topic Kafka ingestion](../02-ingestion/11-stream-from-multiple-topics.ipynb)
+* [ARRAYS and UNNEST](../02-ingestion/08-table-datatypes-arrays.ipynb)
+* [Query from Deep Storage](../03-query/14-sync-async-queries.ipynb)
+* [LOOKUP overload](../03-query/06-lookup-tables.ipynb)
+
+These notebooks were added in support of features that are experimental. Remember to drop [into the community](https://druid.apache.org/community) to give your thoughts, findings, and feedback.
+
+* [Window Functions (Experimental)](../03-query/13-query-functions-window.ipynb)

--- a/notebooks/00-releases/druid-29.md
+++ b/notebooks/00-releases/druid-29.md
@@ -1,0 +1,11 @@
+# Apache Druid 29
+
+* [Ingestion using System Fields](../02-ingestion/02-batch-ingestion.ipynb#system_fields)
+* [IPV6 Support for filtering subnets](../03-query/10-functions-ip.ipynb#ipv6_match)
+* [Control rows per page when retrieving async results](../03-query/14-sync-async-queries.ipynb#async_rows_per_page)
+* [INNER JOIN with inequalities](../03-query/11-joins.ipynb#join_with_inequality)
+* [Expressions for path parameter in JSON functions](../02-ingestion/05-working-with-nested-columns.ipynb#expression_for_path)
+* [PIVOT and UNPIVOT functions](../03-query/15-pivot-unpivot.ipynb)
+* [UNNESTing arrays of objects](../02-ingestion/08-table-datatypes-arrays.ipynb#json_array_of_objects)
+* [Ingest primitive arrays from input source](../02-ingestion/08-table-datatypes-arrays.ipynb#ingest_array)
+* [LATEST/EARLIEST rollup in MSQ](../03-query/01-groupby.ipynb#groupby)

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,14 +1,10 @@
 # Notebook index
 
-Welcome to the notebooks! The index below provides a list of functionality and topics you can find here.
+This index provides a list of notebooks for [ingesting](#ingestion), [querying](#query), and [operating](#operations) Apache Druid.
 
-> When viewing this file inside JupyterLab, right-click anywhere on the page and select "Show Markdown Preview".
+Visit the index of [notebooks by release](./00-releases/) for quick access to new and updated notebooks following different releases of Apache Druid.
 
-If you have suggestions or comments on any notebooks, remember to call into the [discussions](https://github.com/implydata/learn-druid/discussions) board here on Github. Should you want to ask more about the features and how they're used, drop into the [community](https://druid.apache.org/community).
-
-## Releases
-
-You can get quick access to new and updated notebooks following different releases of Apache Druid in the [New Features by Release](#features_by_release) index below.
+There are also [dedicated notebooks](#contributing) that dive more into the components used to create this learning environment.
 
 ## Ingestion
 
@@ -31,7 +27,7 @@ Visit the `02-ingestion` folder for notebooks focused on using JSON- and SQL-bas
 |[ARRAYS and UNNEST](./02-ingestion/08-table-datatypes-arrays.ipynb)|Ingesting, creating, and manipulating ARRAYs and the UNNEST operator.|`druid-jupyter`|
 |[Ingest and query spatial dimensions](./02-ingestion/12-spatial-dimensions.ipynb)|Ingest spatial dimensions and use rectangular, circular, and polygon filters to query.|`druid-jupyter`|
 
-### Query
+## Query
 
 For tutorials focused on effective use of all manner of `SELECT` statements in Apache Druid, see the notebooks in `03-query`.
 
@@ -54,7 +50,7 @@ For tutorials focused on effective use of all manner of `SELECT` statements in A
 |[Query from Deep Storage](./03-query/14-full-timeline-queries.ipynb)|Query from Deep Storage has been enhanced to also view real-time segments making it capable of spanning the whole timeline.|`all-services`| 
 |[PIVOT and UNPIVOT functions](./03-query/15-pivot-unpivot.ipynb)|Use PIVOT to convert row values into columns. Use UNPIVOT to convert column values into rows.|`druid-jupyter`| 
 
-### Operations
+## Operations
 
 The `05-operations` folder contains notebooks related to on-going administration and operation of the Apache Druid database.
 
@@ -72,17 +68,3 @@ The `99-contributing` folder contains notebooks that explain a little more about
 |---|---|---|
 |[Druid Python API](./99-contributing/01-druidapi-package-intro.ipynb)|Learn more about the Python wrapper used by the notebooks.|None|
 |[Data Generator Server](./99-contributing/02-datagen-intro.ipynb)|Learn more about the included Data Generator.|`all-services`|
-
-### New Features by Release
-<a id='features_by_release'></a>
-
-#### Druid 29 
-* [Ingestion using System Fields](./02-ingestion/02-batch-ingestion.ipynb#system_fields)
-* [IPV6 Support for filtering subnects](./03-query/10-functions-ip.ipynb#ipv6_match)
-* [Control rows per page when retrieving async results](./03-query/14-sync-async-queries.ipynb#async_rows_per_page)
-* [INNER JOIN with inequalities](./03-query/11-joins.ipynb#join_with_inequality)
-* [Expressions for path parameter in JSON functions](./02-ingestion/05-working-with-nested-columns.ipynb#expression_for_path)
-* [PIVOT and UNPIVOT functions](./03-query/15-pivot-unpivot.ipynb)
-* [UNNESTing arrays of objects](./02-ingestion/08-table-datatypes-arrays.ipynb#json_array_of_objects)
-* [Ingest primitive arrays from input source](./02-ingestion/08-table-datatypes-arrays.ipynb#ingest_array)
-* [LATEST/EARLIEST rollup in MSQ](./03-query/01-groupby.ipynb#groupby)


### PR DESCRIPTION
Resurrected index page for 28, moved 29 content to its own page. Updated READMEs significantly, including adding the trademark clause for Apache, raising the profile of feedback mechanisms, adding nav to the notebook sections, and shrinking the section on profiles (making it more about the notebooks and less about Docker). Fixed typos and broken links.