### PR TITLE
Remove "book some time"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Come meet the friendly Apache Druid [community](https://druid.apache.org/communi
 
 Imply's courses on Apache Druid at [https://learn.imply.io](https://learn.imply.io) have additional commentary for these notebooks, and you can earn a certificate of completion.
 
-If your team is just getting to know Druid, Imply also offer bookable [team tech talks](https://calendly.com/druidcommunity) on the basics of Apache Druid. And if you want to check whether Apache Druid is the right fit, or would like to get hints on the functionality you should look at, book one of Imply's [getting started with Druid](https://calendly.com/druidcommunity) meetings.
-
 ## Pre-requisites
 
 To use the "Learn Druid" Docker Compose, you need:

--- a/website/courses/data-modeling/index.md
+++ b/website/courses/data-modeling/index.md
@@ -16,17 +16,6 @@ This guide teaches you the fundamentals of ingesting your data into Apache Druid
 
 Each module contains an introductory video, links to Python notebooks in the learn-druid environment, and related material such as docs and community videos.
 
-If you'd like to talk to through what you learn in this course, why not say "hi" to Imply's DevRel team?
-
-
-<div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="https://calendly.com/druidcommunity">
-            Book some time
-          </Link>
-        </div>
-
 ## Welcome video
 
 Watch the following video for an introduction to this course:
@@ -36,7 +25,6 @@ We're in the process of migrating this content. Check back soon.
 :::
 
 <!--TBD UPDATE FINAL VIDEO-->
-
 
 ## Set up your learning environment
 
@@ -52,7 +40,3 @@ We're in the process of migrating this content. Check back soon.
 :::
 
 <!--TBD UPDATE FINAL VIDEO-->
-
-
-
-

--- a/website/courses/druid-basics/index.md
+++ b/website/courses/druid-basics/index.md
@@ -12,16 +12,6 @@ Welcome to the fundamental course on Apache Druid from Imply!
 This course brings together critical learning materials that we think are important to your first half hour with Apache Druid.
 For a short course it's full of information you need to experience and understand Druid.
 
-If you'd like to talk to through what you learn in this course, why not say hi to Imply's DevRel team! Follow this link to find the bookable sessions on offer.
-
-<div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="https://calendly.com/druidcommunity">
-            Book some time
-          </Link>
-        </div>
-
 ## Welcome video
 
 Watch the following video for an introduction to this course:
@@ -60,8 +50,3 @@ See the [Imply website](https://imply.io/) for even more uses for Druid.
 For a sample of the companies using Apache Druid, take a look at the [Powered By page](https://druid.apache.org/druid-powered/).
 You can also watch videos from Apache Druid users at Druid Summit [2023](https://www.youtube.com/playlist?list=PLDZysOZKycN4UZTJ8B3xQXdpqdmK8iiC5), [2022](https://www.youtube.com/playlist?list=PLDZysOZKycN6Bhp8sfenweb0qtRQELbDx), and [2021](https://www.youtube.com/playlist?list=PLDZysOZKycN4FuohgyYNEuI_Azt2ySIE_)
 There you'll find technolgists from Confluent, Reddit, Shopify, PayPal, Rakuten, and Netflix, to name a few.
-
-
-
-
-

--- a/website/courses/druid-monitoring/index.md
+++ b/website/courses/druid-monitoring/index.md
@@ -16,17 +16,6 @@ This course contains:
 - Signposts to videos and important documentation for you to broaden and deepen your understanding.
 - Take time to leave feedback when you're ready; we'd love to use your opinions and thoughts to improve this course for everyone.
 
-If you'd like to talk to through what you learn in this course, why not say hi to Imply's DevRel team! 
-Follow this link to find the bookable sessions on offer.
-
-<div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="https://calendly.com/druidcommunity">
-            Book some time
-          </Link>
-        </div>
-
 ## Welcome
 
 <!--NEED VIDEO-->

--- a/website/courses/druid-streaming/index.md
+++ b/website/courses/druid-streaming/index.md
@@ -16,16 +16,6 @@ This course contains:
 - Signposts to videos and important documentation for you to broaden and deepen your understanding.
 - Take time to leave feedback when you're ready. We'd love to use your opinions and thoughts to improve this course for everyone.
 
-If you'd like to talk to through what you learn in this course, why not say hi to Imply's DevRel team! Follow this link to find the bookable sessions on offer.
-
-<div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="https://calendly.com/druidcommunity">
-            Book some time
-          </Link>
-        </div>
-
 ## Welcome
 
 <!-- NEED VIDEO -->
@@ -36,4 +26,3 @@ We're in the process of migrating this content. Check back soon.
 ## Supervisor specifications
 
 <YouTubePlayer videoId="PnQw2vsRiA4" />
-


### PR DESCRIPTION
Learning resources inherited links to book a session with the Imply DevRel team.

These links are not active.

This PR removes the bookable link button and the preamble.